### PR TITLE
Update artifacts version from v2 to v4

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'      
       - run: |
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'          
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v4
 
       - name: Build resources
         run: sam build --template ${SAM_TEMPLATE}
@@ -59,7 +59,7 @@ jobs:
             --s3-bucket ${ARTIFACTS_BUCKET} \
             --region ${AWS_REGION} \
             --output-template-file packaged-lambda.yaml
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: packaged-lambda.yaml
           path: packaged-lambda.yaml
@@ -72,11 +72,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'          
-      - uses: aws-actions/setup-sam@v2
-      - uses: actions/download-artifact@v2
+      - uses: aws-actions/setup-sam@v4
+      - uses: actions/download-artifact@v4
         with:
           name: packaged-lambda.yaml
 
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-dotnet@v2
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
       - name: Assume the pipeline user role

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'          
-      - uses: aws-actions/setup-sam@v4
+      - uses: aws-actions/setup-sam@v2
 
       - name: Build resources
         run: sam build --template ${SAM_TEMPLATE}
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'          
-      - uses: aws-actions/setup-sam@v4
+      - uses: aws-actions/setup-sam@v2
       - uses: actions/download-artifact@v4
         with:
           name: packaged-lambda.yaml


### PR DESCRIPTION
**Issue:** Due to old version v2 pipeline.yaml file unable to run the pipeline.

**Fix:** To fix the issue I've updated the v2 version to v4 version as described [here](https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/).

**Result:** Everything is working as expected now, without any pipeline errors.